### PR TITLE
Solve Exercise 3.4.*

### DIFF
--- a/textbook/interpreter/example.miniml.ml
+++ b/textbook/interpreter/example.miniml.ml
@@ -4,8 +4,14 @@
 let x = 2
 let y = x * 3;;
 
+(* 9 *)
 let z = 1 in
 x + y + z;;
 
+(* 102 *)
 let x = 100
 and y = x in x+y;;
+
+(* 20 *)
+let threetimes = fun f -> fun x -> f (f x x) (f x x) in
+  threetimes (+) 5;;

--- a/textbook/interpreter/examples/miniml3.miniml.ml
+++ b/textbook/interpreter/examples/miniml3.miniml.ml
@@ -10,3 +10,28 @@ let makefact maker x = if x < 1 then 1 else x * maker maker (x + -1) in
 let fact x = makefact makefact x in
 fact 4
 ;;
+
+(* Exercise 3.4.6 *)
+(* 25 *)
+let fact = fun n -> n + 1 in
+let fact = fun n -> if n < 1 then 1 else n * fact (n + -1) in
+fact 5
+;;
+
+(* 25 *)
+let fact = dfun n -> n + 1 in
+let fact = fun n -> if n < 1 then 1 else n * fact (n + -1) in
+fact 5
+;;
+
+(* 120 *)
+let fact = fun n -> n + 1 in
+let fact = dfun n -> if n < 1 then 1 else n * fact (n + -1) in
+fact 5
+;;
+
+(* 120 *)
+let fact = dfun n -> n + 1 in
+let fact = dfun n -> if n < 1 then 1 else n * fact (n + -1) in
+fact 5
+;;

--- a/textbook/interpreter/examples/miniml3.miniml.ml
+++ b/textbook/interpreter/examples/miniml3.miniml.ml
@@ -1,0 +1,12 @@
+(* Exercise 3.4.4 *)
+(* 12 *)
+let makemult maker x = if x < 1 then 0 else 4 + maker maker (x + -1) in
+let times4 x = makemult makemult x in
+times4 3
+;;
+
+(* 24 *)
+let makefact maker x = if x < 1 then 1 else x * maker maker (x + -1) in
+let fact x = makefact makefact x in
+fact 4
+;;

--- a/textbook/interpreter/src/batch.ml
+++ b/textbook/interpreter/src/batch.ml
@@ -14,4 +14,4 @@ let rec eval_print env lexbuf =
 (* NOTE: No exception handling to perform the same behavior as the original *)
 let read_eval_print filename =
   filename |> MyFile.read_whole |> Lexing.from_string
-  |> eval_print Environment.empty
+  |> eval_print (snd @@ eval_program Environment.empty MyStdlib.program)

--- a/textbook/interpreter/src/cui.ml
+++ b/textbook/interpreter/src/cui.ml
@@ -21,7 +21,7 @@ let rec read_eval_print env =
 let initial_env =
   List.fold_left
     (fun env (id, exval) -> Environment.extend id exval env)
-    Environment.empty
+    (snd @@ eval_program Environment.empty MyStdlib.program)
     [
       ("x", IntV 10);
       ("v", IntV 5);

--- a/textbook/interpreter/src/environment.mli
+++ b/textbook/interpreter/src/environment.mli
@@ -17,3 +17,4 @@ val fold_right : ('a -> 'b -> 'b) -> 'a t -> 'b -> 'b
    Currently, care should be taken not to call this function from production code.
 *)
 val show : (Format.formatter -> 'a -> unit) -> 'a t -> string
+val pp : (Format.formatter -> 'a -> unit) -> Format.formatter -> 'a t -> unit

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -36,7 +36,7 @@ let rec apply_prim op arg1 arg2 =
 let rec eval_exp env = function
   | Var x -> (
       try Environment.lookup x env
-      with Environment.Not_bound -> err ("Variable not bound: " ^ x))
+      with Environment.Not_bound -> err ("Unbounded value " ^ x))
   | ILit i -> IntV i
   | BLit b -> BoolV b
   | BinOp (op, exp1, exp2) ->

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -1,6 +1,11 @@
 open Syntax
 
-type exval = IntV of int | BoolV of bool [@@deriving show]
+type exval =
+  | IntV of int
+  | BoolV of bool
+  | ProcV of id * exp * dnval Environment.t
+[@@deriving show]
+
 and dnval = exval [@@deriving show]
 
 exception Error of string
@@ -11,6 +16,7 @@ let err s = raise (Error s)
 let rec string_of_exval = function
   | IntV i -> string_of_int i
   | BoolV b -> string_of_bool b
+  | ProcV _ -> "<fun>"
 
 let pp_val v = print_string (string_of_exval v)
 
@@ -52,6 +58,15 @@ let rec eval_exp env = function
              env
       in
       eval_exp newenv exp2
+  | FunExp (id, exp) -> ProcV (id, exp, env)
+  | AppExp (exp1, exp2) -> (
+      let funval = eval_exp env exp1 in
+      let arg = eval_exp env exp2 in
+      match funval with
+      | ProcV (id, body, env') ->
+          let newenv = Environment.extend id arg env' in
+          eval_exp newenv body
+      | _ -> err "Non-function value is applied")
 
 let eval_program env = function
   | Exp e ->

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -4,6 +4,7 @@ type exval =
   | IntV of int
   | BoolV of bool
   | ProcV of id * exp * dnval Environment.t
+  | DProcV of id * exp
 [@@deriving show]
 
 and dnval = exval [@@deriving show]
@@ -17,6 +18,7 @@ let rec string_of_exval = function
   | IntV i -> string_of_int i
   | BoolV b -> string_of_bool b
   | ProcV _ -> "<fun>"
+  | DProcV _ -> "<dfun>"
 
 let pp_val v = print_string (string_of_exval v)
 
@@ -59,12 +61,16 @@ let rec eval_exp env = function
       in
       eval_exp newenv exp2
   | FunExp (id, exp) -> ProcV (id, exp, env)
+  | DFunExp (id, exp) -> DProcV (id, exp)
   | AppExp (exp1, exp2) -> (
       let funval = eval_exp env exp1 in
       let arg = eval_exp env exp2 in
       match funval with
       | ProcV (id, body, env') ->
           let newenv = Environment.extend id arg env' in
+          eval_exp newenv body
+      | DProcV (id, body) ->
+          let newenv = Environment.extend id arg env in
           eval_exp newenv body
       | _ -> err "Non-function value is applied")
 

--- a/textbook/interpreter/src/lexer.mll
+++ b/textbook/interpreter/src/lexer.mll
@@ -10,6 +10,7 @@ let reservedWords = [
   ("let", Parser.LET);
   ("and", Parser.AND);
   ("fun", Parser.FUN);
+  ("dfun", Parser.DFUN);
 ]
 }
 

--- a/textbook/interpreter/src/lexer.mll
+++ b/textbook/interpreter/src/lexer.mll
@@ -9,6 +9,7 @@ let reservedWords = [
   ("in", Parser.IN);
   ("let", Parser.LET);
   ("and", Parser.AND);
+  ("fun", Parser.FUN);
 ]
 }
 
@@ -29,6 +30,7 @@ rule main = parse
 | "&&" { Parser.LAND }
 | "||" { Parser.LOR }
 | "=" { Parser.EQ }
+| "->" { Parser.RARROW }
 
 | ['a'-'z'] ['a'-'z' '0'-'9' '_' '\'']*
     { let id = Lexing.lexeme lexbuf in

--- a/textbook/interpreter/src/myStdlib.ml
+++ b/textbook/interpreter/src/myStdlib.ml
@@ -1,0 +1,11 @@
+open Syntax
+
+let program =
+  Decls
+    [
+      [ ("+", FunExp ("x", FunExp ("y", BinOp (Plus, Var "x", Var "y")))) ];
+      [ ("*", FunExp ("x", FunExp ("y", BinOp (Mult, Var "x", Var "y")))) ];
+      [ ("<", FunExp ("x", FunExp ("y", BinOp (Lt, Var "x", Var "y")))) ];
+      [ ("&&", FunExp ("x", FunExp ("y", BinOp (And, Var "x", Var "y")))) ];
+      [ ("||", FunExp ("x", FunExp ("y", BinOp (Or, Var "x", Var "y")))) ];
+    ]

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -6,6 +6,7 @@ open Syntax
 %token PLUS MULT LT LAND LOR
 %token IF THEN ELSE TRUE FALSE
 %token LET IN EQ AND
+%token RARROW FUN
 %token EOF
 
 %token <int> INTV
@@ -27,6 +28,7 @@ Expr :
     e=IfExpr { e }
   | e=LetExpr { e }
   | e=LORExpr { e }
+  | e=FunExpr { e }
 
 LORExpr :
     l=LANDExpr LOR r=LANDExpr { BinOp (Or, l, r) }
@@ -45,7 +47,12 @@ PExpr :
   | e=MExpr { e }
 
 MExpr :
-    l=MExpr MULT r=AExpr { BinOp (Mult, l, r) }
+    l=MExpr MULT r=AppExpr { BinOp (Mult, l, r) }
+  | e=AppExpr { e }
+  | e=AExpr { e }
+
+AppExpr :
+  | e1=AppExpr e2=AExpr { AppExp (e1, e2) }
   | e=AExpr { e }
 
 AExpr :
@@ -57,6 +64,9 @@ AExpr :
 
 IfExpr :
     IF c=Expr THEN t=Expr ELSE e=Expr { IfExp (c, t, e) }
+
+FunExpr :
+  | FUN x=ID RARROW e=Expr { FunExp (x, e) }
 
 LetExpr :
     LET bs=LetBindings IN e=Expr { LetExp (bs, e) }

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -9,7 +9,7 @@ let curry parameters expression =
 %token PLUS MULT LT LAND LOR
 %token IF THEN ELSE TRUE FALSE
 %token LET IN EQ AND
-%token RARROW FUN
+%token RARROW FUN DFUN
 %token EOF
 
 %token <int> INTV
@@ -33,6 +33,7 @@ Expr :
   | e=LetExpr { e }
   | e=LORExpr { e }
   | e=FunExpr { e }
+  | e=DFunExpr { e }
 
 LORExpr :
     l=LANDExpr LOR r=LANDExpr { BinOp (Or, l, r) }
@@ -80,6 +81,9 @@ IfExpr :
 
 FunExpr :
   | FUN params=ParametersPlus RARROW e=Expr { curry params e }
+
+DFunExpr :
+  | DFUN params=ParametersPlus RARROW e=Expr { List.fold_right (fun x acc -> DFunExp (x, acc)) params e }
 
 ParametersPlus :
   | x=ID params=Parameters { x :: params }

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -49,7 +49,6 @@ PExpr :
 MExpr :
     l=MExpr MULT r=AppExpr { BinOp (Mult, l, r) }
   | e=AppExpr { e }
-  | e=AExpr { e }
 
 AppExpr :
   | e1=AppExpr e2=AExpr { AppExp (e1, e2) }
@@ -59,8 +58,18 @@ AExpr :
     i=INTV { ILit i }
   | TRUE   { BLit true }
   | FALSE  { BLit false }
-  | i=ID   { Var i }
+  | name=ValueName   { Var name }
   | LPAREN e=Expr RPAREN { e }
+
+// NOTE:
+// Since I don't know how to convert the token back to the original string,
+// I'm writing it directly, even though it doesn't seem very good.
+BinOp :
+  | PLUS { "+" }
+  | MULT { "*" }
+  | LT { "<" }
+  | LAND { "&&" }
+  | LOR { "||" }
 
 IfExpr :
     IF c=Expr THEN t=Expr ELSE e=Expr { IfExp (c, t, e) }
@@ -72,5 +81,9 @@ LetExpr :
     LET bs=LetBindings IN e=Expr { LetExp (bs, e) }
 
 LetBindings :
-  | x=ID EQ e=Expr { [(x, e)] }
-  | x=ID EQ e=Expr AND l=LetBindings { (x, e) :: l }
+  | x=ValueName EQ e=Expr { [(x, e)] }
+  | x=ValueName EQ e=Expr AND l=LetBindings { (x, e) :: l }
+
+ValueName :
+  | i=ID { i }
+  | LPAREN binOp=BinOp RPAREN { binOp }

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -19,6 +19,7 @@ open Syntax
 toplevel :
     e=Expr SEMISEMI { Exp e }
   | ds=Decls SEMISEMI { Decls ds }
+  | { failwith "Syntax error" }
 
 Decls :
   | { [] }

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -1,5 +1,8 @@
 %{
 open Syntax
+
+let curry parameters expression =
+  List.fold_right (fun x acc -> FunExp (x, acc)) parameters expression
 %}
 
 %token LPAREN RPAREN SEMISEMI
@@ -76,14 +79,21 @@ IfExpr :
     IF c=Expr THEN t=Expr ELSE e=Expr { IfExp (c, t, e) }
 
 FunExpr :
-  | FUN x=ID RARROW e=Expr { FunExp (x, e) }
+  | FUN params=ParametersPlus RARROW e=Expr { curry params e }
+
+ParametersPlus :
+  | x=ID params=Parameters { x :: params }
+
+Parameters :
+  | { [] }
+  | x=ID params=Parameters { x :: params }
 
 LetExpr :
     LET bs=LetBindings IN e=Expr { LetExp (bs, e) }
 
 LetBindings :
-  | x=ValueName EQ e=Expr { [(x, e)] }
-  | x=ValueName EQ e=Expr AND l=LetBindings { (x, e) :: l }
+  | x=ValueName params=Parameters EQ e=Expr { [(x, curry params e)] }
+  | x=ValueName params=Parameters EQ e=Expr AND l=LetBindings { (x, curry params e) :: l }
 
 ValueName :
   | i=ID { i }

--- a/textbook/interpreter/src/syntax.ml
+++ b/textbook/interpreter/src/syntax.ml
@@ -10,6 +10,7 @@ type exp =
   | IfExp of exp * exp * exp
   | LetExp of (id * exp) list * exp
   | FunExp of id * exp
+  | DFunExp of id * exp
   | AppExp of exp * exp
 [@@deriving show]
 

--- a/textbook/interpreter/src/syntax.ml
+++ b/textbook/interpreter/src/syntax.ml
@@ -9,6 +9,8 @@ type exp =
   | BinOp of binOp * exp * exp
   | IfExp of exp * exp * exp
   | LetExp of (id * exp) list * exp
+  | FunExp of id * exp
+  | AppExp of exp * exp
 [@@deriving show]
 
 type program = Exp of exp | Decls of (id * exp) list list [@@deriving show]

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -119,6 +119,28 @@ let () =
                    (LetExp
                       ( [ ("x", ILit 100); ("y", Var "x") ],
                         BinOp (Plus, Var "x", Var "y") )));
+          test_case
+            "The value representing a function is a function closure (c.f. \
+             Chapter3.5 #評価器の拡張: 関数値の表現の仕方)"
+            `Quick (fun () ->
+              check (Eval.IntV 6)
+              @@ Eval.eval_exp
+                   (init_env [ ("x", Eval.IntV 10) ])
+                   (LetExp
+                      ( [
+                          ( "f",
+                            LetExp
+                              ( [ ("x", ILit 2) ],
+                                LetExp
+                                  ( [
+                                      ( "addx",
+                                        FunExp
+                                          ("y", BinOp (Plus, Var "x", Var "y"))
+                                      );
+                                    ],
+                                    Var "addx" ) ) );
+                        ],
+                        AppExp (Var "f", ILit 4) )));
         ] );
       ( "eval_program",
         let check = check environment "" in

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -141,6 +141,23 @@ let () =
                                     Var "addx" ) ) );
                         ],
                         AppExp (Var "f", ILit 4) )));
+          test_case
+            "Support functions that perform dynamic binding (c.f. Exercise \
+             3.4.5)"
+            `Quick (fun () ->
+              check (Eval.IntV 35)
+              @@ Eval.eval_exp Environment.empty
+                   (LetExp
+                      ( [ ("a", ILit 3) ],
+                        LetExp
+                          ( [
+                              ( "p",
+                                DFunExp ("x", BinOp (Plus, Var "x", Var "a")) );
+                            ],
+                            LetExp
+                              ( [ ("a", ILit 5) ],
+                                BinOp (Mult, Var "a", AppExp (Var "p", ILit 2))
+                              ) ) )));
         ] );
       ( "eval_program",
         let check = check environment "" in

--- a/textbook/interpreter/test/parserTest.ml
+++ b/textbook/interpreter/test/parserTest.ml
@@ -37,5 +37,13 @@ let () =
                 (Syntax.Decls
                    [ [ ("x", ILit 1); ("y", ILit 1) ]; [ ("z", ILit 1) ] ])
               @@ program_of_string "let x = 1 and y = 1 let z = 1;;");
+          test_case
+            "Operators enclosed in round brackets are parsed as variable names \
+             (c.f. Exercise 3.4.2)"
+            `Quick (fun () ->
+              check (Syntax.Exp (AppExp (AppExp (Var "+", ILit 1), ILit 1)))
+              @@ program_of_string "( + ) 1 1;;";
+              check (Syntax.Decls [ [ ("+", ILit 1) ] ])
+              @@ program_of_string "let ( + ) = 1;;");
         ] );
     ]

--- a/textbook/interpreter/test/parserTest.ml
+++ b/textbook/interpreter/test/parserTest.ml
@@ -21,7 +21,12 @@ let () =
                       ( Or,
                         BinOp (And, BinOp (Lt, ILit 1, ILit 2), BLit false),
                         BLit true )))
-              @@ program_of_string "1 < 2 && false || true;;");
+              @@ program_of_string "1 < 2 && false || true;;";
+              (* c.f. Chapter 3.5 #関数式と適用式の構文 *)
+              check
+                (Syntax.Exp
+                   (BinOp (Plus, AppExp (FunExp ("x", Var "x"), ILit 1), ILit 1)))
+              @@ program_of_string "(fun x -> x) 1 + 1;;");
           test_case
             "The order in which variables are declared and the order of \
              elements in the list are the same"

--- a/textbook/interpreter/test/parserTest.ml
+++ b/textbook/interpreter/test/parserTest.ml
@@ -61,5 +61,13 @@ let () =
               @@ program_of_string "let f = fun x1 -> 1;;";
               check (program_of_string "let f x1 x2 = 1;;")
               @@ program_of_string "let f = fun x1 x2 -> 1;;");
+          test_case
+            "`dfun x1 x2 ... xn -> e` is the syntax sugar of `dfun x1 -> dfun \
+             x2 -> ... -> dfun xn -> e` (c.f. Exercise 3.4.5)"
+            `Quick (fun () ->
+              check (program_of_string "dfun x1 -> dfun x2 -> 1;;")
+              @@ program_of_string "dfun x1 x2 -> 1;;";
+              check (program_of_string "dfun x1 -> dfun x2 -> dfun x3 -> 1;;")
+              @@ program_of_string "dfun x1 x2 x3 -> 1;;");
         ] );
     ]

--- a/textbook/interpreter/test/parserTest.ml
+++ b/textbook/interpreter/test/parserTest.ml
@@ -45,5 +45,21 @@ let () =
               @@ program_of_string "( + ) 1 1;;";
               check (Syntax.Decls [ [ ("+", ILit 1) ] ])
               @@ program_of_string "let ( + ) = 1;;");
+          test_case
+            "`fun x1 x2 ... xn -> e` is the syntax sugar of `fun x1 -> fun x2 \
+             -> ... -> fun xn -> e` (c.f. Exercise 3.4.3)"
+            `Quick (fun () ->
+              check (program_of_string "fun x1 -> fun x2 -> 1;;")
+              @@ program_of_string "fun x1 x2 -> 1;;";
+              check (program_of_string "fun x1 -> fun x2 -> fun x3 -> 1;;")
+              @@ program_of_string "fun x1 x2 x3 -> 1;;");
+          test_case
+            "`let f x1 x2 ... xn = e` is the syntax sugar of `let f = fun x1 \
+             x2 ... xn -> e` (c.f. Exercise 3.4.3)"
+            `Quick (fun () ->
+              check (program_of_string "let f x1 = 1;;")
+              @@ program_of_string "let f = fun x1 -> 1;;";
+              check (program_of_string "let f x1 x2 = 1;;")
+              @@ program_of_string "let f = fun x1 x2 -> 1;;");
         ] );
     ]


### PR DESCRIPTION
## やったこと

3.5章の Exercise を解いた．

## 意思決定の数々

### 演算子名を表す内部のデータ構造はどうする問題

変数名と同様に文字列で持つことにした．オリジナルで受理される演算子名の数は固定ではないので，これに対応するなら文字列として持つ必要があるから．また，文字列として持ったほうが格段に楽．

### 演算子名として受理する文字列は[こんな感じで](https://v2.ocaml.org/manual/names.html#operator-name)拡張するの問題

拡張せずこれまでと同様に限られた演算子名のみ受理するようにした．演算子名が固定でない場合の演算子の優先順位の付け方がわからなかったから．また，オリジナルでは，`mod` や `or` は演算子名として受理されるため変数名としては受理されず，これを実現しようとすると今回の主題ではない上に大変そうだったから．

### 演算子の意味をどこで定義するか問題

これまでと同様に `Eval.eval_exp` で定義することにした．オリジナルでは，プリミティブな演算の意味はC言語の関数で定義されている [^1] が，これに相当するインタプリタの実装がわからなかったから．

### 中置記法は関数適用に翻訳するか問題

翻訳しないようにした．オリジナルでは，`e1 op e2` は `( op ) e1 e2` に翻訳される [^2] が，翻訳しないほうがデータ構造がパッと見わかりやすいから（例えば `1 + 1` の場合，`BinOp (Plus, ILit 1, ILit 1)` vs `AppExp (AppExp (Var "+", ILit 1), ILit 1)`）．

### 演算子のトークンを文字列にどうやって戻す問題

手動で戻すようにした．おそらくトークンから文字列で戻す関数は定義できないから．

[^1]: https://v2.ocaml.org/manual/intfc.html#ss:c-prim-decl
[^2]: https://v2.ocaml.org/manual/expr.html#ss:expr-operators