### PR TITLE
enable OPAM cache

### DIFF
--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -31,6 +31,7 @@ jobs:
         uses: ocaml/setup-ocaml@v2
         with:
           ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          dune-cache: true
 
       - run: opam install . --deps-only --with-test
 


### PR DESCRIPTION
## 動機

MiniML に導入した GitHub Actions のワークフローが遅すぎて，PR を高速にマージできない．

## やったこと

[Set up OCaml](https://github.com/marketplace/actions/set-up-ocaml) のキャッシュを有効にした．