### PR TITLE
fix a problem that variable bindings can be reduced from function application

### DIFF
--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -56,16 +56,19 @@ toplevel :
   | { failwith "Syntax error" }
 
 Expr :
-  | n=ValueName { Var n }
-  | c=Constant { c }
-  | LPAREN e=Expr RPAREN { e }
-  | e1=Expr e2=Expr %prec APP { AppExp (e1, e2) }
+  | e=Expr_ { e }
+  | e1=Expr e2=Expr_ %prec APP { AppExp (e1, e2) }
   | e1=Expr op=BinOp e2=Expr { BinOp (op, e1, e2) }
   | IF e1=Expr THEN e2=Expr ELSE e3=Expr { IfExp (e1, e2, e3) }
   | FUN params=nonempty_list(ID) RARROW e=Expr { curry params e }
   | DFUN params=nonempty_list(ID) RARROW e=Expr { List.fold_right (fun x acc -> DFunExp (x, acc)) params e }
   | LET bs=LetBindings IN e=Expr { LetExp (bs, e) }
   | LET REC bs=LetRecBindings IN e2=Expr { LetRecExp (bs, e2) }
+
+Expr_ :
+  | n=ValueName { Var n }
+  | c=Constant { c }
+  | LPAREN e=Expr RPAREN { e }
 
 %inline ValueName :
   | i=ID { i }

--- a/textbook/interpreter/test/parserTest.ml
+++ b/textbook/interpreter/test/parserTest.ml
@@ -84,5 +84,10 @@ let () =
                   ignore @@ program_of_string "let rec id x = x;;");
               check_raises "" Parser.Error (fun () ->
                   ignore @@ program_of_string "let rec id x = x in 1;;"));
+          test_case
+            "Variable bindings cannot be reduced from function application"
+            `Quick (fun () ->
+              check_raises "" Parser.Error (fun () ->
+                  ignore @@ program_of_string "id let foo = 1 in foo;;"));
         ] );
     ]


### PR DESCRIPTION
## 動機

OCaml 本家と挙動が違う点があった．

### 本家

```ocaml
# id let foo = 1 in foo;;
Error: Syntax error
```

### MiniML

```ocaml
# id let foo = 1 in foo;;
parsing done
val - = 1
```

## やったこと

関数適用のルール `e1 e2` において，`e2` では変数束縛のルールが現れないようにした．