### PR TITLE
Change the function eval to return evaluation result and environment

### DIFF
--- a/textbook/interpreter/main.ml
+++ b/textbook/interpreter/main.ml
@@ -6,5 +6,5 @@ let _ =
     | _cmd :: args -> args
   in
   match args with
-  | [] -> Miniml.Cui.read_eval_print Miniml.Cui.initial_env
+  | [] -> Miniml.Cui.read_eval_print ()
   | filename :: _ -> Miniml.Batch.read_eval_print filename

--- a/textbook/interpreter/src/batch.ml
+++ b/textbook/interpreter/src/batch.ml
@@ -1,16 +1,7 @@
-open Eval
-
-let rec eval_print env lexbuf =
-  (* NOTE:
-     `Lexer.main` seems to execute `exit 0`
-     when a certain string (an unacceptble string?; ex. "\n") is inputted. *)
-  let program = Parser.unit_implementation Lexer.main lexbuf in
-  let defs, _newenv = eval_program env program in
-  List.iter
-    (fun (id, v) -> Printf.printf "val %s = %s\n" id (string_of_exval v))
-    defs
-
 (* NOTE: No exception handling to perform the same behavior as the original *)
 let read_eval_print filename =
   filename |> MyFile.read_whole |> Lexing.from_string
-  |> eval_print (snd @@ eval_program Environment.empty MyStdlib.program)
+  |> Parser.unit_implementation Lexer.main
+  |> PrettyEval.eval_program
+       (Eval.eval_program Environment.empty MyStdlib.program)
+  |> fst |> PrettyEval.string_of_results |> print_endline

--- a/textbook/interpreter/src/batch.mli
+++ b/textbook/interpreter/src/batch.mli
@@ -1,1 +1,0 @@
-val read_eval_print : string -> unit

--- a/textbook/interpreter/src/cui.mli
+++ b/textbook/interpreter/src/cui.mli
@@ -1,0 +1,1 @@
+val read_eval_print : unit -> 'a

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -114,8 +114,4 @@ let eval_item env = function
       (None, newenv)
 
 let eval_program env items =
-  List.fold_left
-    (fun (bounds, newenv) item ->
-      let new_bounds, newenv = eval_item newenv item in
-      (List.append bounds new_bounds, newenv))
-    ([], env) items
+  List.fold_left (fun env item -> snd @@ eval_item env item) env items

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -87,11 +87,20 @@ let rec eval_exp env = function
           eval_exp newenv body
       | _ -> err "Non-function value is applied")
 
+let raise_if_id_duplicates ids =
+  let ids' = List.sort_uniq compare ids in
+  match MyList.subtract ids ids' with
+  | [] -> ()
+  | id :: _ ->
+      err
+      @@ Printf.sprintf "Variable %s is bound several times in this matching" id
+
 let eval_item env = function
   | Exp e ->
       let v = eval_exp env e in
       (Some v, env)
   | Def bindings ->
+      bindings |> List.map (fun (id, _) -> id) |> raise_if_id_duplicates;
       let bounds = bindings |> List.map (fun (id, e) -> (id, eval_exp env e)) in
       let newenv =
         List.fold_left
@@ -100,6 +109,7 @@ let eval_item env = function
       in
       (None, newenv)
   | RecDef bindings ->
+      bindings |> List.map (fun (id, _, _) -> id) |> raise_if_id_duplicates;
       let dummyenv = ref Environment.empty in
       let bounds =
         bindings

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -13,15 +13,6 @@ exception Error of string
 
 let err s = raise (Error s)
 
-(* pretty printing *)
-let rec string_of_exval = function
-  | IntV i -> string_of_int i
-  | BoolV b -> string_of_bool b
-  | ProcV _ -> "<fun>"
-  | DProcV _ -> "<dfun>"
-
-let pp_val v = print_string (string_of_exval v)
-
 let rec apply_prim op arg1 arg2 =
   match (op, arg1, arg2) with
   | Plus, IntV i1, IntV i2 -> IntV (i1 + i2)

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -90,7 +90,7 @@ let rec eval_exp env = function
 let eval_item env = function
   | Exp e ->
       let v = eval_exp env e in
-      ([ ("-", v) ], env)
+      (Some v, env)
   | Def bindings ->
       let bounds = bindings |> List.map (fun (id, e) -> (id, eval_exp env e)) in
       let newenv =
@@ -98,7 +98,7 @@ let eval_item env = function
           (fun newenv (id, v) -> Environment.extend id v newenv)
           env bounds
       in
-      (bounds, newenv)
+      (None, newenv)
   | RecDef bindings ->
       let dummyenv = ref Environment.empty in
       let bounds =
@@ -111,7 +111,7 @@ let eval_item env = function
           env bounds
       in
       dummyenv := newenv;
-      (bounds, newenv)
+      (None, newenv)
 
 let eval_program env items =
   List.fold_left

--- a/textbook/interpreter/src/myList.ml
+++ b/textbook/interpreter/src/myList.ml
@@ -1,0 +1,6 @@
+let rec remove elem = function
+  | [] -> []
+  | x :: xs when x = elem -> xs
+  | x :: xs -> x :: remove elem xs
+
+let subtract xs ys = List.fold_left (fun acc y -> remove y acc) xs ys

--- a/textbook/interpreter/src/parser.mly
+++ b/textbook/interpreter/src/parser.mly
@@ -60,6 +60,8 @@ toplevel_input :
       { defs }
   | e=Expr SEMISEMI
       { [Exp e] }
+  | EOF
+      { exit 0 }
   | { failwith "Syntax error" }
 
 // NOTE:

--- a/textbook/interpreter/src/prettyEval.ml
+++ b/textbook/interpreter/src/prettyEval.ml
@@ -1,0 +1,31 @@
+type results = (Syntax.id * Eval.exval) list
+
+let extract_variable_names_to_be_defined = function
+  | Syntax.Exp _exp -> []
+  | Def bindings -> bindings |> List.map (fun (id, _v) -> id)
+  | RecDef bindings -> bindings |> List.map (fun (id, _param, _v) -> id)
+
+let eval_program env program =
+  List.fold_left
+    (fun (results, env) item ->
+      let v, newenv = Eval.eval_item env item in
+      let ids = extract_variable_names_to_be_defined item in
+      let results' =
+        match v with
+        | Some v' -> [ ("-", v') ]
+        | None -> List.map (fun id -> (id, Environment.lookup id newenv)) ids
+      in
+      (List.append results results', newenv))
+    ([], env) program
+
+let string_of_exval = function
+  | Eval.IntV i -> string_of_int i
+  | BoolV b -> string_of_bool b
+  | ProcV _ -> "<fun>"
+  | DProcV _ -> "<dfun>"
+
+let string_of_results results =
+  results
+  |> List.map (fun (id, exval) ->
+         Printf.sprintf "val %s = %s" id @@ string_of_exval exval)
+  |> String.concat "\n"

--- a/textbook/interpreter/src/prettyEval.mli
+++ b/textbook/interpreter/src/prettyEval.mli
@@ -1,0 +1,8 @@
+type results = (string * Eval.exval) list
+
+val eval_program :
+  Eval.exval Environment.t ->
+  Syntax.item list ->
+  (string * Eval.exval) list * Eval.exval Environment.t
+
+val string_of_results : (string * Eval.exval) list -> string

--- a/textbook/interpreter/test/dune
+++ b/textbook/interpreter/test/dune
@@ -1,3 +1,3 @@
 (tests
- (names evalTest lexerTest parserTest)
+ (names evalTest lexerTest parserTest myListTest)
  (libraries miniml alcotest))

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -217,17 +217,15 @@ let () =
             "When evaluating an equation, the environment remains the same"
             `Quick (fun () ->
               check_environment Environment.empty
-              @@ snd
               @@ Eval.eval_program Environment.empty [ Syntax.Exp (ILit 1) ];
               check_environment Environment.empty
-              @@ snd
               @@ Eval.eval_program Environment.empty
                    [ Syntax.Exp (LetExp ([ ("x", ILit 1) ], Var "x")) ]);
           test_case
             "Variables can be declared in sequence (c.f. Exercise 3.3.2)" `Quick
             (fun () ->
               let expected = init_env [ ("x", Eval.IntV 1); ("y", IntV 2) ] in
-              let _, actual =
+              let actual =
                 Eval.eval_program Environment.empty
                 @@ [
                      Syntax.Def [ ("x", ILit 1) ];
@@ -248,7 +246,7 @@ let () =
                     ("z", IntV 10);
                   ]
               in
-              let _, actual =
+              let actual =
                 Eval.eval_program
                   (init_env [ ("x", Eval.IntV 10) ])
                   [
@@ -264,7 +262,7 @@ let () =
                  Since printing a recursive function does not stop
                  (because it contains itself in the environment),
                  test with the result of the recursive function computation. *)
-              let _, newenv =
+              let newenv =
                 Eval.eval_program Environment.empty
                 @@ [
                      Syntax.RecDef
@@ -293,7 +291,7 @@ let () =
                  Since printing a recursive function does not stop
                  (because it contains itself in the environment),
                  test with the result of the recursive function computation. *)
-              let _, newenv =
+              let newenv =
                 Eval.eval_program Environment.empty
                 @@ [
                      Syntax.RecDef

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -209,6 +209,20 @@ let () =
                         ],
                         AppExp (Var "even", ILit 2) )));
         ] );
+      ( "eval_item",
+        [
+          test_case
+            "Variables cannot be bound several times in the same matching"
+            `Quick (fun () ->
+              try
+                ignore
+                @@ Eval.eval_item Environment.empty
+                     (Def [ ("x", ILit 1); ("x", ILit 2) ]);
+                fail "No exception"
+              with
+              | Eval.Error _ -> ignore pass
+              | _ -> fail "Unexpected exception");
+        ] );
       ( "eval_program",
         let check_environment = check environment "" in
         let check_exval = check exval "" in

--- a/textbook/interpreter/test/myListTest.ml
+++ b/textbook/interpreter/test/myListTest.ml
@@ -1,0 +1,44 @@
+open Miniml
+
+let program = Syntax.show_program |> Fmt.of_to_string |> Alcotest.of_pp
+
+let program_of_string str =
+  Parser.toplevel_input Lexer.main (Lexing.from_string str)
+
+let () =
+  let open Alcotest in
+  run "MyList"
+    [
+      ( "remove",
+        let check = check (list int) "" in
+        [
+          test_case
+            "If there is no element to be removed, return the given list" `Quick
+            (fun () ->
+              check [] @@ MyList.remove 1 [];
+              check [ 2 ] @@ MyList.remove 1 [ 2 ];
+              check [ 2; 3 ] @@ MyList.remove 1 [ 2; 3 ]);
+          test_case "Delete only one applicable element" `Quick (fun () ->
+              check [] @@ MyList.remove 1 [ 1 ];
+              check [ 2 ] @@ MyList.remove 1 [ 2; 1 ];
+              check [ 2; 1 ] @@ MyList.remove 1 [ 1; 2; 1 ]);
+        ] );
+      ( "subtract",
+        let check = check (list int) "" in
+        [
+          test_case
+            "If there are no duplicates in the two given lists, return the \
+             first argument"
+            `Quick (fun () ->
+              check [] @@ MyList.subtract [] [];
+              check [] @@ MyList.subtract [] [ 1; 2 ];
+              check [ 1; 2 ] @@ MyList.subtract [ 1; 2 ] []);
+          test_case
+            "remove elements from the first argument lsit that are included in \
+             the second argument list"
+            `Quick (fun () ->
+              check [] @@ MyList.subtract [ 1; 2 ] [ 1; 2 ];
+              check [ 1; 2 ] @@ MyList.subtract [ 1; 2; 3; 4 ] [ 3; 4 ];
+              check [ 1; 2 ] @@ MyList.subtract [ 1; 1; 2; 2 ] [ 1; 2 ]);
+        ] );
+    ]


### PR DESCRIPTION
## 動機

これまで変数定義の順序は `Eval` モジュールの関数内で付けられていた．しかし，変数定義の順序は表示上の問題であって評価器の責務ではないし，このまま行くと型推論器内でも変数定義の順序を気にする必要が生じて大変だと予見された．

## やったこと

評価結果をいい感じに扱う `Eval` モジュールのラッパーモジュール `PrettyEval` を定義し，`Eval` モジュールではプログラムの評価のみを行うようにした．また，テストを通すために REPL やバッチインタプリタでは `PrettyEval` を用いて評価結果を表示するようにした．

### 同名の変数を同時に束縛する場合について

これまでは同名の変数を同時に束縛できたが，これをできないようにした．理由は2つあり，1つ目は今回の `PrettyEval` が行っている評価結果を表示する方法では同名の変数が同時に束縛されると都合が悪いからで，2つ目は本家の OCaml でもこれを許していないからである．

```ocaml
# let x = 1 and x = 2;;
Error: Variable x is bound several times in this matching
```