### PR TITLE
Check MiniML grammar for ambiguity in CI

### DIFF
--- a/.github/workflows/dune.yml
+++ b/.github/workflows/dune.yml
@@ -38,3 +38,8 @@ jobs:
       - run: opam exec -- dune build
 
       - run: opam exec -- dune runtest
+
+      - name: Check MiniML grammar for ambiguity
+        run: |
+          opam exec -- menhir --explain src/parser.mly || true
+          [ ! -s src/parser.conflicts ]


### PR DESCRIPTION
## 動機

`master` に存在する MiniML の文法は曖昧じゃないことを保証したい．

## やったこと

`menhir` コマンドでコンフリクトの説明ファイルを生成し，そのファイルが空かどうか CI で判定する．