### PR TITLE
Develop the type inference algorithm for MiniML3

### DIFF
--- a/textbook/interpreter/cram/miniml3.t/exercise3-4-4.miniml.ml
+++ b/textbook/interpreter/cram/miniml3.t/exercise3-4-4.miniml.ml
@@ -1,9 +1,11 @@
 (* Factorial Calculation without `rec` *)
+(* NOTE: In OCaml, this expression cannot be typed. *)
 let makemult maker x = if x < 1 then 0 else 4 + maker maker (x + -1) in
 let times4 x = makemult makemult x in
 times4 3
 ;;
 
+(* NOTE: In OCaml, this expression cannot be typed. *)
 let makefact maker x = if x < 1 then 1 else x * maker maker (x + -1) in
 let fact x = makefact makefact x in
 fact 4

--- a/textbook/interpreter/cram/miniml3.t/run.t
+++ b/textbook/interpreter/cram/miniml3.t/run.t
@@ -2,16 +2,16 @@ Function introduction
 
 Exercise 3.4.1
   $ dune exec miniml exercise3-4-1.miniml.ml
-  val - = 6
+  val - : int = 6
 
 Exercise 3.4.2
   $ dune exec miniml exercise3-4-2.miniml.ml
-  val - = 20
+  val - : int = 20
 
 Exercise 3.4.3
   $ dune exec miniml exercise3-4-3.miniml.ml
-  val - = 3
-  val - = 3
+  val - : int = 3
+  val - : int = 3
 
 Exercise 3.4.4
   $ dune exec miniml exercise3-4-4.miniml.ml
@@ -21,11 +21,11 @@ Exercise 3.4.4
 Exercise 3.4.5
   $ dune exec miniml exercise3-4-5.miniml.ml
   val - = 35
-  val - = 25
+  val - : int = 25
 
 Exercise 3.4.6
   $ dune exec miniml exercise3-4-6.miniml.ml
-  val - = 25
+  val - : int = 25
   val - = 25
   val - = 120
   val - = 120

--- a/textbook/interpreter/src/batch.ml
+++ b/textbook/interpreter/src/batch.ml
@@ -1,9 +1,25 @@
+(* TODO:
+   When type inference of variable definitions becomes possible,
+   there is no need to declare types explicitly. *)
+let initial_tyenv =
+  let open Syntax in
+  List.fold_left
+    (fun tyenv (id, ty) -> Environment.extend id ty tyenv)
+    Environment.empty
+    [
+      ("+", TyFun (TyInt, TyFun (TyInt, TyInt)));
+      ("*", TyFun (TyInt, TyFun (TyInt, TyInt)));
+      ("=", TyFun (TyInt, TyFun (TyInt, TyBool)));
+      ("<", TyFun (TyInt, TyFun (TyInt, TyBool)));
+      ("&&", TyFun (TyBool, TyFun (TyBool, TyBool)));
+      ("||", TyFun (TyBool, TyFun (TyBool, TyBool)));
+    ]
+
 (* NOTE: No exception handling to perform the same behavior as the original *)
 let read_eval_print filename =
   let fst = function x, _, _ -> x in
   let env = Eval.eval_program Environment.empty MyStdlib.program in
-  let tyenv = Environment.empty in
   filename |> MyFile.read_whole |> Lexing.from_string
   |> Parser.unit_implementation Lexer.main
-  |> Run.run_program env tyenv |> fst |> Run.string_of_run_results
-  |> print_endline
+  |> Run.run_program env initial_tyenv
+  |> fst |> Run.string_of_run_results |> print_endline

--- a/textbook/interpreter/src/cui.ml
+++ b/textbook/interpreter/src/cui.ml
@@ -38,6 +38,12 @@ let initial_tyenv =
       ("ii", TyInt);
       ("iii", TyInt);
       ("iv", TyInt);
+      ("+", TyFun (TyInt, TyFun (TyInt, TyInt)));
+      ("*", TyFun (TyInt, TyFun (TyInt, TyInt)));
+      ("=", TyFun (TyInt, TyFun (TyInt, TyBool)));
+      ("<", TyFun (TyInt, TyFun (TyInt, TyBool)));
+      ("&&", TyFun (TyBool, TyFun (TyBool, TyBool)));
+      ("||", TyFun (TyBool, TyFun (TyBool, TyBool)));
     ]
 
 let read_eval_print () =

--- a/textbook/interpreter/src/typing.ml
+++ b/textbook/interpreter/src/typing.ml
@@ -5,6 +5,7 @@ exception Error of string
 let err s = raise (Error s)
 
 type tyenv = ty Environment.t
+type subst = (tyvar * ty) list
 
 let string_of_binop = function
   | Plus -> "+"
@@ -14,50 +15,141 @@ let string_of_binop = function
   | And -> "&&"
   | Or -> "||"
 
-let string_of_ty = function TyInt -> "int" | TyBool -> "bool"
+let string_of_tyvar tyvar =
+  Printf.sprintf "'%c" @@ Char.chr (Char.code 'a' + tyvar)
+
+let rec string_of_ty = function
+  | TyInt -> "int"
+  | TyBool -> "bool"
+  | TyVar tyvar -> string_of_tyvar tyvar
+  | TyFun ((TyFun _ as ty1), ty2) ->
+      Printf.sprintf "(%s) -> %s" (string_of_ty ty1) (string_of_ty ty2)
+  | TyFun (ty1, ty2) ->
+      Printf.sprintf "%s -> %s" (string_of_ty ty1) (string_of_ty ty2)
+  | _ -> err "Not Implemented!"
+
+let fresh_tyvar =
+  let counter = ref 0 in
+  let body () =
+    let v = !counter in
+    counter := v + 1;
+    v
+  in
+  body
+
+let freevar_ty ty =
+  let rec freevar_ty' ty set =
+    match ty with
+    | TyVar tyvar -> MySet.insert tyvar set
+    | TyFun (ty1, ty2) -> set |> freevar_ty' ty1 |> freevar_ty' ty2
+    | _ -> set
+  in
+  freevar_ty' ty MySet.empty
+
+(* NOTE:
+    The elements of `subst` are assumed to be topologically sorted with respect to `tyvar`.
+    That is, ∀ (tyvar₁, ty₁), (tyvar₂, ty₂) ∈ subst, ∃ i, j ∈ int,
+    (tyvar₁, ty₁) = List.nth subst i ∧ (tyvar₂, ty₂) = List.nth subst j ∧ i ≤ j → tyvar₁ ∉ FTV(ty₂),
+    where `FTV(ty)` is the set of type variables that appear in `ty`. *)
+let rec subst_type subst = function
+  | TyInt -> TyInt
+  | TyBool -> TyBool
+  | TyVar tyvar -> (
+      match List.assoc_opt tyvar subst with
+      | Some b -> subst_type (List.tl subst) b
+      | None -> TyVar tyvar)
+  | TyFun (ty1, ty2) -> TyFun (subst_type subst ty1, subst_type subst ty2)
+  | _ -> err "Not Implemented!"
+
+let eqs_of_subst subst = List.map (fun (tyvar, ty) -> (TyVar tyvar, ty)) subst
+let eqs_of_substs substs = substs |> List.map eqs_of_subst |> List.flatten
+
+let subst_eqs subst eqs =
+  List.map (fun (ty1, ty2) -> (subst_type subst ty1, subst_type subst ty2)) eqs
+
+let occur_check tyvar ty =
+  if MySet.member tyvar @@ freevar_ty ty then err "tyvar ∈ FTV(ty)"
+
+let rec unify = function
+  | [] -> []
+  | eq :: eqs -> (
+      match eq with
+      | ty1, ty2 when ty1 = ty2 -> unify eqs
+      | TyFun (ty11, ty12), TyFun (ty21, ty22) ->
+          unify @@ [ (ty11, ty21); (ty12, ty22) ] @ eqs
+      | TyVar tyvar, ty ->
+          occur_check tyvar ty;
+          (unify @@ subst_eqs [ (tyvar, ty) ] eqs) @ [ (tyvar, ty) ]
+      | ty, TyVar tyvar ->
+          occur_check tyvar ty;
+          (unify @@ subst_eqs [ (tyvar, ty) ] eqs) @ [ (tyvar, ty) ]
+      | _ -> err "Cannot unify")
 
 let ty_prim op ty1 ty2 =
   match op with
-  | Plus | Mult | Eq | Lt -> (
-      match (ty1, ty2) with
-      | TyInt, TyInt -> TyInt
-      | _ -> err ("Argument must be of integer: " ^ string_of_binop op))
-  | And | Or -> (
-      match (ty1, ty2) with
-      | TyBool, TyBool -> TyBool
-      | _ -> err ("Argument must be of boolean: " ^ string_of_binop op))
+  | Plus | Mult -> ([ (ty1, TyInt); (ty2, TyInt) ], TyInt)
+  | Eq | Lt -> ([ (ty1, TyInt); (ty2, TyInt) ], TyBool)
+  | And | Or -> ([ (ty1, TyBool); (ty2, TyBool) ], TyBool)
 
 let rec ty_exp tyenv = function
   | Var x -> (
-      try Environment.lookup x tyenv
+      try ([], Environment.lookup x tyenv)
       with Environment.Not_bound -> err ("variable not bound: " ^ x))
-  | ILit _ -> TyInt
-  | BLit _ -> TyBool
+  | ILit _ -> ([], TyInt)
+  | BLit _ -> ([], TyBool)
   | BinOp (op, exp1, exp2) ->
-      let tyarg1 = ty_exp tyenv exp1 in
-      let tyarg2 = ty_exp tyenv exp2 in
-      ty_prim op tyarg1 tyarg2
-  | IfExp (exp1, exp2, exp3) -> (
-      match ty_exp tyenv exp1 with
-      | TyBool -> (
-          match (ty_exp tyenv exp2, ty_exp tyenv exp3) with
-          | ty1, ty2 when ty1 = ty2 -> ty1
-          | ty1, _ ->
-              err ("Else expression must be " ^ string_of_ty ty1 ^ ": if"))
-      | _ -> err "Test expression must be boolean: if")
-  | LetExp (bindings, exp2) ->
-      let tyenv' =
-        bindings
-        |> List.map (fun (id, exp1) -> (id, ty_exp tyenv exp1))
-        |> List.fold_left
-             (fun tyenv' (id, ty) -> Environment.extend id ty tyenv')
-             tyenv
+      let subst1, ty1 = ty_exp tyenv exp1 in
+      let subst2, ty2 = ty_exp tyenv exp2 in
+      let eqs, ty = ty_prim op ty1 ty2 in
+      let subst = unify @@ eqs_of_subst subst1 @ eqs_of_subst subst2 @ eqs in
+      (subst, subst_type subst ty)
+  | IfExp (exp1, exp2, exp3) ->
+      let subst1, ty1 = ty_exp tyenv exp1 in
+      let subst2, ty2 = ty_exp tyenv exp2 in
+      let subst3, ty3 = ty_exp tyenv exp3 in
+      let subst =
+        unify
+        @@ eqs_of_substs [ subst1; subst2; subst3 ]
+        @ [ (ty1, TyBool); (ty2, ty3) ]
       in
-      ty_exp tyenv' exp2
+      (subst, subst_type subst ty2)
+  | LetExp (bindings, exp2) ->
+      let id_subst_ty_list =
+        List.map
+          (fun (id, exp) ->
+            let subst, ty = ty_exp tyenv exp in
+            (id, subst, ty))
+          bindings
+      in
+      let tyenv' =
+        List.fold_left
+          (fun tyenv (id, _, ty) -> Environment.extend id ty tyenv)
+          tyenv id_subst_ty_list
+      in
+      let subst1 =
+        List.fold_left
+          (fun subst (_, subst', _) -> subst' @ subst)
+          [] id_subst_ty_list
+      in
+      let subst2, ty2 = ty_exp tyenv' exp2 in
+      let subst = unify @@ eqs_of_substs [ subst1; subst2 ] in
+      (subst, subst_type subst ty2)
+  | FunExp (id, exp) ->
+      let ty1 = TyVar (fresh_tyvar ()) in
+      let subst, ty2 = ty_exp (Environment.extend id ty1 tyenv) exp in
+      (subst, TyFun (subst_type subst ty1, ty2))
+  | AppExp (exp1, exp2) ->
+      let ty2 = TyVar (fresh_tyvar ()) in
+      let subst1, ty12 = ty_exp tyenv exp1 in
+      let subst2, ty1 = ty_exp tyenv exp2 in
+      let subst =
+        unify @@ eqs_of_substs [ subst1; subst2 ] @ [ (ty12, TyFun (ty1, ty2)) ]
+      in
+      (subst, subst_type subst ty2)
   | _ -> err "Not Implemented!"
 
 let ty_item tyenv = function
   | Exp e ->
-      let ty = ty_exp tyenv e in
+      let _, ty = ty_exp tyenv e in
       (Some ty, tyenv)
   | _ -> err "Not Implemented!"

--- a/textbook/interpreter/test/typingTest.ml
+++ b/textbook/interpreter/test/typingTest.ml
@@ -15,20 +15,22 @@ let () =
   run "Typing"
     [
       ( "ty_prim",
-        let check = check ty "" in
+        let check = check (pair (list (pair ty ty)) ty) "" in
         [
-          test_case "Plus: int -> int -> int" `Quick (fun () ->
-              check TyInt @@ Typing.ty_prim Plus TyInt TyInt);
-          test_case "Mult: int -> int -> int" `Quick (fun () ->
-              check TyInt @@ Typing.ty_prim Mult TyInt TyInt);
-          test_case "Eq: int -> int -> int" `Quick (fun () ->
-              check TyInt @@ Typing.ty_prim Eq TyInt TyInt);
-          test_case "Lt: int -> int -> int" `Quick (fun () ->
-              check TyInt @@ Typing.ty_prim Lt TyInt TyInt);
-          test_case "And: bool -> bool -> bool" `Quick (fun () ->
-              check TyBool @@ Typing.ty_prim And TyBool TyBool);
-          test_case "Or: bool -> bool -> bool" `Quick (fun () ->
-              check TyBool @@ Typing.ty_prim Or TyBool TyBool);
+          test_case "Returns constraints and a return type" `Quick (fun () ->
+              let open Syntax in
+              check ([ (TyInt, TyInt); (TyInt, TyInt) ], TyInt)
+              @@ Typing.ty_prim Plus TyInt TyInt;
+              check ([ (TyInt, TyInt); (TyInt, TyInt) ], TyInt)
+              @@ Typing.ty_prim Mult TyInt TyInt;
+              check ([ (TyInt, TyInt); (TyInt, TyInt) ], TyBool)
+              @@ Typing.ty_prim Eq TyInt TyInt;
+              check ([ (TyInt, TyInt); (TyInt, TyInt) ], TyBool)
+              @@ Typing.ty_prim Lt TyInt TyInt;
+              check ([ (TyBool, TyBool); (TyBool, TyBool) ], TyBool)
+              @@ Typing.ty_prim And TyBool TyBool;
+              check ([ (TyBool, TyBool); (TyBool, TyBool) ], TyBool)
+              @@ Typing.ty_prim Or TyBool TyBool);
         ] );
       ( "ty_exp",
         let check = check ty "" in
@@ -37,8 +39,8 @@ let () =
               let tyenv =
                 init_env [ ("y", Syntax.TyInt); ("y", TyBool); ("x", TyInt) ]
               in
-              check TyInt @@ Typing.ty_exp tyenv (Var "x");
-              check TyBool @@ Typing.ty_exp tyenv (Var "y"));
+              check TyInt @@ snd (Typing.ty_exp tyenv (Var "x"));
+              check TyBool @@ snd (Typing.ty_exp tyenv (Var "y")));
           test_case "Referencing an unbounded variable raises an exception"
             `Quick (fun () ->
               try
@@ -49,24 +51,31 @@ let () =
               | _ -> fail "Unexpected exception");
           test_case "Literals are mapped to the corresponding types" `Quick
             (fun () ->
-              check TyInt @@ Typing.ty_exp Environment.empty (ILit 1);
-              check TyBool @@ Typing.ty_exp Environment.empty (BLit true));
+              check TyInt @@ snd (Typing.ty_exp Environment.empty (ILit 1));
+              check TyBool @@ snd (Typing.ty_exp Environment.empty (BLit true)));
           test_case "Inference result is the same of `ty_prim`" `Quick
             (fun () ->
-              check (Typing.ty_prim Plus TyInt TyInt)
-              @@ Typing.ty_exp Environment.empty (BinOp (Plus, ILit 0, ILit 1));
-              check (Typing.ty_prim Mult TyInt TyInt)
-              @@ Typing.ty_exp Environment.empty (BinOp (Mult, ILit 0, ILit 1))
+              let open Syntax in
+              check (snd (Typing.ty_prim Plus TyInt TyInt))
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (BinOp (Plus, ILit 0, ILit 1)));
+              check (snd (Typing.ty_prim Mult TyInt TyInt))
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (BinOp (Mult, ILit 0, ILit 1)))
               (* NOTE: Omit for other operators *));
           test_case
             "The type of if expression is the same as then and else clauses"
             `Quick (fun () ->
               check TyInt
-              @@ Typing.ty_exp Environment.empty
-                   (IfExp (BLit true, ILit 1, ILit 0));
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (IfExp (BLit true, ILit 1, ILit 0)));
               check TyBool
-              @@ Typing.ty_exp Environment.empty
-                   (IfExp (BLit true, BLit true, BLit false)));
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (IfExp (BLit true, BLit true, BLit false))));
           test_case "The types of then and else clauses must be the same" `Quick
             (fun () ->
               try
@@ -80,7 +89,61 @@ let () =
           test_case "Variables can be referenced after variable binding" `Quick
             (fun () ->
               check TyInt
-              @@ Typing.ty_exp Environment.empty
-                   (LetExp ([ ("x", ILit 1) ], Var "x")));
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (LetExp ([ ("x", ILit 1) ], Var "x"))));
+          test_case "Monomorphic type can be inferred" `Quick (fun () ->
+              check (TyFun (TyInt, TyInt))
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (FunExp ("x", BinOp (Plus, Var "x", ILit 1))));
+              check (TyFun (TyInt, TyFun (TyInt, TyInt)))
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (FunExp ("x", FunExp ("y", BinOp (Plus, Var "x", Var "y"))))));
+          test_case "Return type can be inferred" `Quick (fun () ->
+              check TyInt
+              @@ snd
+                   (Typing.ty_exp Environment.empty
+                      (AppExp
+                         (FunExp ("x", BinOp (Plus, Var "x", ILit 1)), ILit 2))));
+        ] );
+      ( "fresh_tyvar",
+        let check = check int "" in
+        [
+          test_case "Generated `tyvar`s are not duplicated" `Quick (fun () ->
+              let len = 100 in
+              check len
+              @@ (List.init len (fun _ -> Typing.fresh_tyvar ())
+                 |> List.sort_uniq compare |> List.length));
+        ] );
+      ( "subst_type",
+        let check = check ty "" in
+        [
+          test_case
+            "A type is substituted to a type variable based on a type \
+             substitution (c.f. Exercise 4.3.2)"
+            `Quick (fun () ->
+              let alpha = Typing.fresh_tyvar () in
+              let beta = Typing.fresh_tyvar () in
+              let gamma = Typing.fresh_tyvar () in
+              check (TyFun (TyInt, TyBool))
+              @@ Typing.subst_type
+                   [ (alpha, TyInt) ]
+                   (TyFun (TyVar alpha, TyBool));
+              check (TyFun (TyBool, TyInt))
+              @@ Typing.subst_type
+                   [ (gamma, TyFun (TyVar beta, TyInt)); (beta, TyBool) ]
+                   (TyVar gamma));
+          test_case
+            "Type substitution is performed in the order of the elements of \
+             `subst` (c.f. Exercise 4.3.2)"
+            `Quick (fun () ->
+              let beta = Typing.fresh_tyvar () in
+              let gamma = Typing.fresh_tyvar () in
+              check (TyFun (TyVar beta, TyInt))
+              @@ Typing.subst_type
+                   [ (beta, TyBool); (gamma, TyFun (TyVar beta, TyInt)) ]
+                   (TyVar gamma));
         ] );
     ]


### PR DESCRIPTION
Exercise 4.3.1, 4.3.2, 4.3.3, 4.3.5 を解いた．

## Exercise 4.3.4

> 単一化アルゴリズムにおいて，オカーチェックの条件 $\alpha \notin \text{FTV}(\tau)$ はなぜ必要か考察せよ．

制約を解けないから．例えば $\alpha = \alpha \to \alpha$ を満たす $\tau \in \\{ \texttt{int}, \texttt{bool}, \tau_1 \to \tau_2 \\}$ は存在しない……みたいな理由だと思う．