### PR TITLE
Support type inference of variable definitions

### DIFF
--- a/textbook/interpreter/cram/miniml2.t/run.t
+++ b/textbook/interpreter/cram/miniml2.t/run.t
@@ -2,18 +2,18 @@ Definition introduction
 
 Exercise 3.3.1
   $ dune exec miniml exercise3-3-1.miniml.ml
-  val x = 10
+  val x : int = 10
   val - : int = 15
 
 Exercise 3.3.2
   $ dune exec miniml exercise3-3-2.miniml.ml
-  val x = 1
-  val y = 2
+  val x : int = 1
+  val y : int = 2
 
 Exercise 3.3.3
 (No specific test)
 
 Exercise 3.3.4
   $ dune exec miniml exercise3-3-4.miniml.ml
-  val x = 10
-  val - = 110
+  val x : int = 10
+  val - : int = 110

--- a/textbook/interpreter/src/batch.ml
+++ b/textbook/interpreter/src/batch.ml
@@ -1,25 +1,10 @@
-(* TODO:
-   When type inference of variable definitions becomes possible,
-   there is no need to declare types explicitly. *)
-let initial_tyenv =
-  let open Syntax in
-  List.fold_left
-    (fun tyenv (id, ty) -> Environment.extend id ty tyenv)
-    Environment.empty
-    [
-      ("+", TyFun (TyInt, TyFun (TyInt, TyInt)));
-      ("*", TyFun (TyInt, TyFun (TyInt, TyInt)));
-      ("=", TyFun (TyInt, TyFun (TyInt, TyBool)));
-      ("<", TyFun (TyInt, TyFun (TyInt, TyBool)));
-      ("&&", TyFun (TyBool, TyFun (TyBool, TyBool)));
-      ("||", TyFun (TyBool, TyFun (TyBool, TyBool)));
-    ]
-
 (* NOTE: No exception handling to perform the same behavior as the original *)
 let read_eval_print filename =
   let fst = function x, _, _ -> x in
-  let env = Eval.eval_program Environment.empty MyStdlib.program in
+  let _, env, tyenv =
+    Run.run_program Environment.empty Environment.empty MyStdlib.program
+  in
   filename |> MyFile.read_whole |> Lexing.from_string
   |> Parser.unit_implementation Lexer.main
-  |> Run.run_program env initial_tyenv
-  |> fst |> Run.string_of_run_results |> print_endline
+  |> Run.run_program env tyenv |> fst |> Run.string_of_run_results
+  |> print_endline

--- a/textbook/interpreter/src/cui.ml
+++ b/textbook/interpreter/src/cui.ml
@@ -23,31 +23,9 @@ let initial_program =
     Def [ ("iv", ILit 4) ];
   ]
 
-(* TODO:
-   When type inference of variable definitions becomes possible,
-   there is no need to declare types explicitly. *)
-let initial_tyenv =
-  let open Syntax in
-  List.fold_left
-    (fun tyenv (id, ty) -> Environment.extend id ty tyenv)
-    Environment.empty
-    [
-      ("x", TyInt);
-      ("v", TyInt);
-      ("i", TyInt);
-      ("ii", TyInt);
-      ("iii", TyInt);
-      ("iv", TyInt);
-      ("+", TyFun (TyInt, TyFun (TyInt, TyInt)));
-      ("*", TyFun (TyInt, TyFun (TyInt, TyInt)));
-      ("=", TyFun (TyInt, TyFun (TyInt, TyBool)));
-      ("<", TyFun (TyInt, TyFun (TyInt, TyBool)));
-      ("&&", TyFun (TyBool, TyFun (TyBool, TyBool)));
-      ("||", TyFun (TyBool, TyFun (TyBool, TyBool)));
-    ]
-
 let read_eval_print () =
-  let env =
-    MyStdlib.program @ initial_program |> Eval.eval_program Environment.empty
+  let _, env, tyenv =
+    MyStdlib.program @ initial_program
+    |> Run.run_program Environment.empty Environment.empty
   in
-  read_eval_print' env initial_tyenv
+  read_eval_print' env tyenv


### PR DESCRIPTION
## 動機

現在は式の型推論しかできないため，標準ライブラリ関数の型付けのためには明示的に型環境を作らなければならなくて面倒．また，変数定義の型推論は課題としては出題されていないが，出来るだけ多くの MiniML の機能を型推論したい気持ちがある．

## やったこと

`Typing.ty_item` における第二引数の値が `Def` コンストラクタのパターンを実装した．また，定義済みの変数の型が後から判明する場合があるため，式の型推論の最後で型環境に型代入するようにした．