### PR TITLE
Support type inference of recursive definition

### DIFF
--- a/textbook/interpreter/cram/miniml3.t/run.t
+++ b/textbook/interpreter/cram/miniml3.t/run.t
@@ -13,10 +13,11 @@ Exercise 3.4.3
   val - : int = 3
   val - : int = 3
 
+NOTE: This program cannot be typed in OCaml's type system, so it is only tested with `evalTest.ml`.
 Exercise 3.4.4
-  $ dune exec miniml exercise3-4-4.miniml.ml
-  val - = 12
-  val - = 24
+$ dune exec miniml exercise3-4-4.miniml.ml
+val - = 12
+val - = 24
 
 Exercise 3.4.5
   $ dune exec miniml exercise3-4-5.miniml.ml

--- a/textbook/interpreter/cram/miniml4.t/run.t
+++ b/textbook/interpreter/cram/miniml4.t/run.t
@@ -2,13 +2,13 @@ Recursive function introduction
 
 Exercise 3.5.1
   $ dune exec miniml exercise3-5-1.miniml.ml
-  val - = 120
-  val fib = <fun>
-  val - = 55
+  val - : int = 120
+  val fib : int -> int = <fun>
+  val - : int = 55
 
 Exercise 3.5.2
   $ dune exec miniml exercise3-5-2.miniml.ml
-  val even = <fun>
-  val odd = <fun>
-  val - = true
-  val - = false
+  val even : int -> bool = <fun>
+  val odd : int -> bool = <fun>
+  val - : bool = true
+  val - : bool = false

--- a/textbook/interpreter/src/eval.ml
+++ b/textbook/interpreter/src/eval.ml
@@ -84,20 +84,11 @@ let rec eval_exp env = function
           eval_exp newenv body
       | _ -> err "Non-function value is applied")
 
-let raise_if_id_duplicates ids =
-  let ids' = List.sort_uniq compare ids in
-  match MyList.subtract ids ids' with
-  | [] -> ()
-  | id :: _ ->
-      err
-      @@ Printf.sprintf "Variable %s is bound several times in this matching" id
-
 let eval_item env = function
   | Exp e ->
       let v = eval_exp env e in
       (Some v, env)
   | Def bindings ->
-      bindings |> List.map (fun (id, _) -> id) |> raise_if_id_duplicates;
       let bounds = bindings |> List.map (fun (id, e) -> (id, eval_exp env e)) in
       let newenv =
         List.fold_left
@@ -106,7 +97,6 @@ let eval_item env = function
       in
       (None, newenv)
   | RecDef bindings ->
-      bindings |> List.map (fun (id, _, _) -> id) |> raise_if_id_duplicates;
       let dummyenv = ref Environment.empty in
       let bounds =
         bindings

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -209,20 +209,6 @@ let () =
                         ],
                         AppExp (Var "even", ILit 2) )));
         ] );
-      ( "eval_item",
-        [
-          test_case
-            "Variables cannot be bound several times in the same matching"
-            `Quick (fun () ->
-              try
-                ignore
-                @@ Eval.eval_item Environment.empty
-                     (Def [ ("x", ILit 1); ("x", ILit 2) ]);
-                fail "No exception"
-              with
-              | Eval.Error _ -> ignore pass
-              | _ -> fail "Unexpected exception");
-        ] );
       ( "eval_program",
         let check_environment = check environment "" in
         let check_exval = check exval "" in

--- a/textbook/interpreter/test/evalTest.ml
+++ b/textbook/interpreter/test/evalTest.ml
@@ -145,6 +145,70 @@ let () =
                         ],
                         AppExp (Var "f", ILit 4) )));
           test_case
+            "Even untypeable expressions may be able to evaluate (c.f. \
+             Exercise 3.4.4)"
+            `Quick (fun () ->
+              check (Eval.IntV 12)
+              @@ Eval.eval_exp Environment.empty
+                   (LetExp
+                      ( [
+                          ( "makemult",
+                            FunExp
+                              ( "maker",
+                                FunExp
+                                  ( "x",
+                                    IfExp
+                                      ( BinOp (Lt, Var "x", ILit 1),
+                                        ILit 0,
+                                        BinOp
+                                          ( Plus,
+                                            ILit 4,
+                                            AppExp
+                                              ( AppExp (Var "maker", Var "maker"),
+                                                BinOp (Plus, Var "x", ILit ~-1)
+                                              ) ) ) ) ) );
+                        ],
+                        LetExp
+                          ( [
+                              ( "times4",
+                                FunExp
+                                  ( "x",
+                                    AppExp
+                                      ( AppExp (Var "makemult", Var "makemult"),
+                                        Var "x" ) ) );
+                            ],
+                            AppExp (Var "times4", ILit 3) ) ));
+              check (Eval.IntV 24)
+              @@ Eval.eval_exp Environment.empty
+                   (LetExp
+                      ( [
+                          ( "makefact",
+                            FunExp
+                              ( "maker",
+                                FunExp
+                                  ( "x",
+                                    IfExp
+                                      ( BinOp (Lt, Var "x", ILit 1),
+                                        ILit 1,
+                                        BinOp
+                                          ( Mult,
+                                            Var "x",
+                                            AppExp
+                                              ( AppExp (Var "maker", Var "maker"),
+                                                BinOp (Plus, Var "x", ILit ~-1)
+                                              ) ) ) ) ) );
+                        ],
+                        LetExp
+                          ( [
+                              ( "fact",
+                                FunExp
+                                  ( "x",
+                                    AppExp
+                                      ( AppExp (Var "makefact", Var "makefact"),
+                                        Var "x" ) ) );
+                            ],
+                            AppExp (Var "fact", ILit 4) ) )));
+          test_case
             "Support functions that perform dynamic binding (c.f. Exercise \
              3.4.5)"
             `Quick (fun () ->


### PR DESCRIPTION
Exercise 4.3.6 を解いた．

## 「同名の変数は同時に定義できない」という制約はどこで検査する？

今までは評価時に検査していたが，[オリジナルの OCaml](https://github.com/ocaml/ocaml/blob/trunk/typing/typecore.ml#L5714) に倣い，型検査時に検査することにした．